### PR TITLE
feat(options): support option for sanitizing null properties.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Currently uses the following rules:
 - Removes null characters (ie. `\0`) from string values
 - Deletes from the payload keys with a value of empty string (ie. `''`), or optionally replaces them with a different value
 - Deletes from the payload keys with a value consisting entirely of whitespace (ie. `' \t\n '`), or optionally replaces them with a different value
+- Optionally deletes/replaces `null` values
 
 ## Registering the plugin
 
@@ -28,3 +29,4 @@ server.register([
   - `'delete'` - the key will be removed from the payload entirely (ie. `{ a: '', b: 'b' }` :arrow_right: `{ b: 'b' }`)
   - `'replace'` - the key will be preserved, but its value will be replaced with the value of `replaceValue`
 - `replaceValue` - valid only when `pruneMethod` is set to `'replace'`, this value will be used as the replacement of any pruned values (ie. if configured as `null`, then `{ a: '', b: 'b' }` :arrow_right: `{ a: null, b: 'b' }`)
+- `stripNull` - a boolean value to signify whether or not `null` properties should be pruned with the same `pruneMethod` and `replaceValue` as above

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,6 +10,7 @@ var NULL_CHAR_REGEX = /\0/g;
 
 var schema = Joi.object()
   .keys({
+    stripNull: Joi.boolean().optional().default(false),
     pruneMethod: Joi.string().valid('delete', 'replace').required(),
     replaceValue: Joi.when('pruneMethod', {
       is: 'replace',
@@ -19,7 +20,8 @@ var schema = Joi.object()
   })
   .empty({})
   .default({
-    pruneMethod: 'delete'
+    pruneMethod: 'delete',
+    stripNull: false
   });
 
 function isEmptyOrBlank (str) {
@@ -40,10 +42,12 @@ function sanitize (obj, options) {
 
     if (isPlainObject(value)) {
       obj[key] = sanitize(value, options);
-    } else if (isString(value)) {
-      obj[key] = stripNullTerminator(value);
+    } else {
+      if (isString(value)) {
+        obj[key] = stripNullTerminator(value);
+      }
 
-      if (isEmptyOrBlank(obj[key])) {
+      if ((options.stripNull && value === null) || isEmptyOrBlank(obj[key])) {
         if (options.pruneMethod === 'replace') {
           obj[key] = options.replaceValue;
         } else {


### PR DESCRIPTION
**What**: Add an opt-in option for sanitizing `null` payload inputs.

**Why**: This might be desired in servers that hope to service `x-www-form-urlencoded` and `json` payloads equally as the former treats `null` values as the empty string, which this plugin sanitizes by default.