### PR TITLE
feat(config): allow disabling in the route config

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,20 @@ server.register([
   - `'replace'` - the key will be preserved, but its value will be replaced with the value of `replaceValue`
 - `replaceValue` - valid only when `pruneMethod` is set to `'replace'`, this value will be used as the replacement of any pruned values (ie. if configured as `null`, then `{ a: '', b: 'b' }` :arrow_right: `{ a: null, b: 'b' }`)
 - `stripNull` - a boolean value to signify whether or not `null` properties should be pruned with the same `pruneMethod` and `replaceValue` as above
+
+You can also set disable the plugin on a route-by-route basis too using the `sanitize` plugin object.
+
+```js
+server.route({
+  method: 'POST',
+  path: '/users',
+  config: {
+    plugins: {
+      sanitize: { enabled: false }
+    },
+    handler: function () {
+      // handler logic
+    }
+  }
+});
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -70,7 +70,9 @@ exports.register = function (server, options, next) {
   options = result.value;
 
   server.ext('onPostAuth', function (request, reply) {
-    if (request.method !== 'get' && isPlainObject(request.payload)) {
+    var routeOptions = request.route.settings.plugins.sanitize || {};
+
+    if (request.method !== 'get' && isPlainObject(request.payload) && routeOptions.enabled !== false) {
       request.payload = sanitize(request.payload, options);
     }
 


### PR DESCRIPTION
### What

Allow individual routes to disable the entire plugin.

### Why

Some times this functionality isn't needed and causes adverse effects.