### PR TITLE
feat(options): support property override

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ server.register([
   - `'replace'` - the key will be preserved, but its value will be replaced with the value of `replaceValue`.
 - `replaceValue` - valid only when `pruneMethod` is set to `'replace'`, this value will be used as the replacement of any pruned values (ie. if configured as `null`, then `{ a: '', b: 'b' }` :arrow_right: `{ a: null, b: 'b' }`).
 - `stripNull` - a boolean value to signify whether or not `null` properties should be pruned with the same `pruneMethod` and `replaceValue` as above. Defaults to `false`.
+- `fieldOverride` - an object where each key is a a property and its value is an object of options (`enabled`, `pruneMethod`, `replaceValue`, and `stripNull`). The options value overrides the default options for that given property.
 
 Each of the above options can be configured on a route-by-route basis via the `sanitize` plugin object.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ server.register([
   - `'replace'` - the key will be preserved, but its value will be replaced with the value of `replaceValue`.
 - `replaceValue` - valid only when `pruneMethod` is set to `'replace'`, this value will be used as the replacement of any pruned values (ie. if configured as `null`, then `{ a: '', b: 'b' }` :arrow_right: `{ a: null, b: 'b' }`).
 - `stripNull` - a boolean value to signify whether or not `null` properties should be pruned with the same `pruneMethod` and `replaceValue` as above. Defaults to `false`.
-- `fieldOverride` - an object where each key is a a property and its value is an object of options (`pruneMethod`, `replaceValue`, and `stripNull`). The options value overrides the default options for that given property.
+- `fieldOverrides` - an object where each key is a a property and its value is an object of options (`pruneMethod`, `replaceValue`, and `stripNull`). The options value overrides the default options for that given property.
 
 Each of the above options can be configured on a route-by-route basis via the `sanitize` plugin object.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ server.register([
   - `'replace'` - the key will be preserved, but its value will be replaced with the value of `replaceValue`.
 - `replaceValue` - valid only when `pruneMethod` is set to `'replace'`, this value will be used as the replacement of any pruned values (ie. if configured as `null`, then `{ a: '', b: 'b' }` :arrow_right: `{ a: null, b: 'b' }`).
 - `stripNull` - a boolean value to signify whether or not `null` properties should be pruned with the same `pruneMethod` and `replaceValue` as above. Defaults to `false`.
-- `fieldOverride` - an object where each key is a a property and its value is an object of options (`enabled`, `pruneMethod`, `replaceValue`, and `stripNull`). The options value overrides the default options for that given property.
+- `fieldOverride` - an object where each key is a a property and its value is an object of options (`pruneMethod`, `replaceValue`, and `stripNull`). The options value overrides the default options for that given property.
 
 Each of the above options can be configured on a route-by-route basis via the `sanitize` plugin object.
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -9,7 +9,6 @@ const defaults = {
 };
 
 const options = Joi.object().keys({
-  enabled: Joi.boolean().optional(),
   pruneMethod: Joi.string().valid('delete', 'replace').optional(),
   replaceValue: Joi.when('pruneMethod', {
     is: 'replace',
@@ -20,6 +19,7 @@ const options = Joi.object().keys({
 });
 
 const schema = Joi.object().keys({
+  enabled: Joi.boolean().optional(),
   // no double quotes or backslashes
   fieldOverride: Joi.object().pattern(/^[^"\\]$/, options).optional()
 }).concat(options);

--- a/lib/options.js
+++ b/lib/options.js
@@ -21,7 +21,7 @@ const options = Joi.object().keys({
 const schema = Joi.object().keys({
   enabled: Joi.boolean().optional(),
   // no double quotes or backslashes
-  fieldOverride: Joi.object().pattern(/^[^"\\]$/, options).optional()
+  fieldOverrides: Joi.object().pattern(/^[^"\\]$/, options).optional()
 }).concat(options);
 
 exports.defaults = defaults;

--- a/lib/options.js
+++ b/lib/options.js
@@ -8,7 +8,7 @@ const defaults = {
   stripNull: false
 };
 
-const schema = Joi.object().keys({
+const options = Joi.object().keys({
   enabled: Joi.boolean().optional(),
   pruneMethod: Joi.string().valid('delete', 'replace').optional(),
   replaceValue: Joi.when('pruneMethod', {
@@ -18,6 +18,11 @@ const schema = Joi.object().keys({
   }),
   stripNull: Joi.boolean().optional()
 });
+
+const schema = Joi.object().keys({
+  // no double quotes or backslashes
+  fieldOverride: Joi.object().pattern(/^[^"\\]$/, options).optional()
+}).concat(options);
 
 exports.defaults = defaults;
 exports.schema = schema;

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Assign        = require('lodash.assign');
 const CloneDeep     = require('lodash.clonedeep');
 const IsPlainObject = require('lodash.isplainobject');
 const IsString      = require('lodash.isstring');
@@ -25,7 +26,7 @@ function Sanitize (object, options) {
   options = options || {};
 
   Object.keys(object).forEach((key) => {
-    const overrideOptions = options.fieldOverride && options.fieldOverride[key] || options;
+    const overrideOptions = options.fieldOverride && Assign({}, options.fieldOverride[key]) || options;
     let value = object[key];
 
     if (IsPlainObject(value)) {

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -25,7 +25,7 @@ function Sanitize (object, options) {
   options = options || {};
 
   Object.keys(object).forEach((key) => {
-    const fieldOptions = options.fieldOverride ? options.fieldOverride[key] : {};
+    const fieldOptions = options.fieldOverrides ? options.fieldOverrides[key] : {};
     const overrideOptions = Object.assign({}, options, fieldOptions);
 
     let value = object[key];

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -25,18 +25,19 @@ function Sanitize (object, options) {
   options = options || {};
 
   Object.keys(object).forEach((key) => {
+    const overrideOptions = options.fieldOverride && options.fieldOverride[key] || options;
     let value = object[key];
 
     if (IsPlainObject(value)) {
-      object[key] = Sanitize(value, options);
+      object[key] = Sanitize(value, overrideOptions);
     } else {
       if (IsString(value)) {
         object[key] = value = stripNullTerminator(value).trim();
       }
 
-      if (options.stripNull && value === null || isBlank(value)) {
-        if (options.pruneMethod === 'replace') {
-          object[key] = options.replaceValue;
+      if (overrideOptions.stripNull && value === null || isBlank(value)) {
+        if (overrideOptions.pruneMethod === 'replace') {
+          object[key] = overrideOptions.replaceValue;
         } else {
           Unset(object, key);
         }

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -26,7 +26,9 @@ function Sanitize (object, options) {
   options = options || {};
 
   Object.keys(object).forEach((key) => {
-    const overrideOptions = options.fieldOverride && Assign({}, options.fieldOverride[key]) || options;
+    const fieldOptions = options.fieldOverride ? options.fieldOverride[key] : {};
+    const overrideOptions = Assign({}, options, fieldOptions);
+
     let value = object[key];
 
     if (IsPlainObject(value)) {

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Assign        = require('lodash.assign');
 const CloneDeep     = require('lodash.clonedeep');
 const IsPlainObject = require('lodash.isplainobject');
 const IsString      = require('lodash.isstring');
@@ -27,7 +26,7 @@ function Sanitize (object, options) {
 
   Object.keys(object).forEach((key) => {
     const fieldOptions = options.fieldOverride ? options.fieldOverride[key] : {};
-    const overrideOptions = Assign({}, options, fieldOptions);
+    const overrideOptions = Object.assign({}, options, fieldOptions);
 
     let value = object[key];
 

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "homepage": "https://github.com/lob/hapi-sanitize-payload",
   "dependencies": {
     "joi": "^9.2.0",
-    "lodash.isstring": "^4.0.1",
-    "lodash.isplainobject": "^4.0.6",
     "lodash.clonedeep": "^4.5.0",
+    "lodash.isplainobject": "^4.0.6",
+    "lodash.isstring": "^4.0.1",
     "lodash.unset": "^4.5.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "homepage": "https://github.com/lob/hapi-sanitize-payload",
   "dependencies": {
     "joi": "^9.2.0",
-    "lodash.assign": "^4.2.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.isplainobject": "^4.0.6",
     "lodash.isstring": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "homepage": "https://github.com/lob/hapi-sanitize-payload",
   "dependencies": {
     "joi": "^9.2.0",
+    "lodash.assign": "^4.2.0",
     "lodash.clonedeep": "^4.5.0",
     "lodash.isplainobject": "^4.0.6",
     "lodash.isstring": "^4.0.1",

--- a/test/sanitize.test.js
+++ b/test/sanitize.test.js
@@ -118,4 +118,122 @@ describe('sanitize', () => {
     expect(result).to.eql(input);
   });
 
+  it('overrides options on certain keys if fieldOverride is passed in', () => {
+    const input = {
+      key1: 'b\0ar',
+      key2: '   bye',
+      key3: '\0why  ',
+      key4: '',
+      key5: null
+    };
+
+    const defaultResult = Sanitize(input);
+    const overrideResult = Sanitize(input, {
+      fieldOverride: {
+        key4: {
+          pruneMethod: 'replace',
+          replaceValue: null
+        }
+      }
+    });
+
+    expect(defaultResult).to.eql({
+      key1: 'bar',
+      key2: 'bye',
+      key3: 'why',
+      key5: null
+    });
+    expect(overrideResult).to.eql({
+      key1: 'bar',
+      key2: 'bye',
+      key3: 'why',
+      key4: null,
+      key5: null
+    });
+  });
+
+  it('overrides options on certain keys if fieldOverride is passed in', () => {
+    const input = {
+      key1: 'b\0ar',
+      key2: '   bye',
+      key3: '\0why  ',
+      key4: ' ',
+      key5: null
+    };
+
+    const defaultResult = Sanitize(input);
+    const overrideResult = Sanitize(input, {
+      fieldOverride: {
+        key4: {
+          pruneMethod: 'replace',
+          replaceValue: null
+        }
+      }
+    });
+
+    expect(defaultResult).to.eql({
+      key1: 'bar',
+      key2: 'bye',
+      key3: 'why',
+      key5: null
+    });
+    expect(overrideResult).to.eql({
+      key1: 'bar',
+      key2: 'bye',
+      key3: 'why',
+      key4: null,
+      key5: null
+    });
+  });
+
+  it(`overrides options on nested objects if fieldOverride is passed in`, () => {
+    const input = {
+      key1: {
+        nested1: 'b\0ar',
+        nested2: '',
+        nested3: '  '
+      },
+      key2: 'bye',
+      key3: {
+        nested1: 'b\0ar',
+        nested2: '',
+        nested3: '  '
+      },
+      key4: '\0bye '
+    };
+
+    const defaultResult = Sanitize(input);
+    const overrideResult = Sanitize(input, {
+      fieldOverride: {
+        key1: {
+          pruneMethod: 'replace',
+          replaceValue: undefined
+        }
+      }
+    });
+
+    expect(defaultResult).to.eql({
+      key1: {
+        nested1: 'bar'
+      },
+      key2: 'bye',
+      key3: {
+        nested1: 'bar'
+      },
+      key4: 'bye'
+    });
+    expect(overrideResult).to.eql({
+      key1: {
+        nested1: 'bar',
+        nested2: undefined,
+        nested3: undefined
+      },
+      key2: 'bye',
+      key3: {
+        nested1: 'bar'
+      },
+      key4: 'bye'
+    });
+  });
+
 });

--- a/test/sanitize.test.js
+++ b/test/sanitize.test.js
@@ -118,7 +118,7 @@ describe('sanitize', () => {
     expect(result).to.eql(input);
   });
 
-  it('overrides options on certain keys if fieldOverride is passed in', () => {
+  it('overrides options on certain keys if fieldOverrides is passed in', () => {
     const input = {
       key1: 'b\0ar',
       key2: '   bye',
@@ -127,9 +127,8 @@ describe('sanitize', () => {
       key5: null
     };
 
-    const defaultResult = Sanitize(input);
     const overrideResult = Sanitize(input, {
-      fieldOverride: {
+      fieldOverrides: {
         key4: {
           pruneMethod: 'replace',
           replaceValue: null
@@ -137,12 +136,6 @@ describe('sanitize', () => {
       }
     });
 
-    expect(defaultResult).to.eql({
-      key1: 'bar',
-      key2: 'bye',
-      key3: 'why',
-      key5: null
-    });
     expect(overrideResult).to.eql({
       key1: 'bar',
       key2: 'bye',
@@ -152,7 +145,7 @@ describe('sanitize', () => {
     });
   });
 
-  it('overrides options on certain keys with existing options if fieldOverride is passed in', () => {
+  it('overrides options on certain keys with existing options if fieldOverrides is passed in', () => {
     const input = {
       key1: 'b\0ar',
       key2: '   bye',
@@ -161,29 +154,17 @@ describe('sanitize', () => {
       key5: null
     };
 
-    const defaultResult = Sanitize(input, {
-      pruneMethod: 'replace',
-      replaceValue: 'hi',
-      stripNull: true
-    });
     const overrideResult = Sanitize(input, {
       pruneMethod: 'replace',
       replaceValue: 'hi',
       stripNull: true,
-      fieldOverride: {
+      fieldOverrides: {
         key4: {
           replaceValue: null
         }
       }
     });
 
-    expect(defaultResult).to.eql({
-      key1: 'bar',
-      key2: 'bye',
-      key3: 'why',
-      key4: 'hi',
-      key5: 'hi'
-    });
     expect(overrideResult).to.eql({
       key1: 'bar',
       key2: 'bye',
@@ -193,7 +174,7 @@ describe('sanitize', () => {
     });
   });
 
-  it('overrides options on nested objects if fieldOverride is passed in', () => {
+  it('overrides options on nested objects if fieldOverrides is passed in', () => {
     const input = {
       key1: {
         nested1: 'b\0ar',
@@ -209,9 +190,8 @@ describe('sanitize', () => {
       key4: '\0bye '
     };
 
-    const defaultResult = Sanitize(input);
     const overrideResult = Sanitize(input, {
-      fieldOverride: {
+      fieldOverrides: {
         key1: {
           pruneMethod: 'replace',
           replaceValue: undefined
@@ -219,16 +199,6 @@ describe('sanitize', () => {
       }
     });
 
-    expect(defaultResult).to.eql({
-      key1: {
-        nested1: 'bar'
-      },
-      key2: 'bye',
-      key3: {
-        nested1: 'bar'
-      },
-      key4: 'bye'
-    });
     expect(overrideResult).to.eql({
       key1: {
         nested1: 'bar',
@@ -243,7 +213,7 @@ describe('sanitize', () => {
     });
   });
 
-  it('overrides options on nested objects with existing options if fieldOverride is passed in', () => {
+  it('overrides options on nested objects with existing options if fieldOverrides is passed in', () => {
     const input = {
       key1: {
         nested1: 'b\0ar',
@@ -259,36 +229,17 @@ describe('sanitize', () => {
       key4: '\0bye '
     };
 
-    const defaultResult = Sanitize(input, {
-      pruneMethod: 'replace',
-      replaceValue: 'hi',
-      stripNull: true
-    });
     const overrideResult = Sanitize(input, {
       pruneMethod: 'replace',
       replaceValue: 'hi',
       stripNull: true,
-      fieldOverride: {
+      fieldOverrides: {
         key1: {
           replaceValue: undefined
         }
       }
     });
 
-    expect(defaultResult).to.eql({
-      key1: {
-        nested1: 'bar',
-        nested2: 'hi',
-        nested3: 'hi'
-      },
-      key2: 'bye',
-      key3: {
-        nested1: 'bar',
-        nested2: 'hi',
-        nested3: 'hi'
-      },
-      key4: 'bye'
-    });
     expect(overrideResult).to.eql({
       key1: {
         nested1: 'bar',
@@ -305,7 +256,7 @@ describe('sanitize', () => {
     });
   });
 
-  it('does not override any option if fieldOverride with nonexistent keys is passed in', () => {
+  it('does not override any option if fieldOverrides with nonexistent keys is passed in', () => {
     const input = {
       key1: 'b\0ar',
       key2: '   bye',
@@ -314,9 +265,8 @@ describe('sanitize', () => {
       key5: null
     };
 
-    const defaultResult = Sanitize(input);
     const overrideResult = Sanitize(input, {
-      fieldOverride: {
+      fieldOverrides: {
         key6: {
           pruneMethod: 'replace',
           replaceValue: null
@@ -324,7 +274,7 @@ describe('sanitize', () => {
       }
     });
 
-    expect(defaultResult).to.eql(overrideResult).to.eql({
+    expect(overrideResult).to.eql({
       key1: 'bar',
       key2: 'bye',
       key3: 'why',

--- a/test/sanitize.test.js
+++ b/test/sanitize.test.js
@@ -305,4 +305,31 @@ describe('sanitize', () => {
     });
   });
 
+  it('does not override any option if fieldOverride with nonexistent keys is passed in', () => {
+    const input = {
+      key1: 'b\0ar',
+      key2: '   bye',
+      key3: '\0why  ',
+      key4: ' ',
+      key5: null
+    };
+
+    const defaultResult = Sanitize(input);
+    const overrideResult = Sanitize(input, {
+      fieldOverride: {
+        key6: {
+          pruneMethod: 'replace',
+          replaceValue: null
+        }
+      }
+    });
+
+    expect(defaultResult).to.eql(overrideResult).to.eql({
+      key1: 'bar',
+      key2: 'bye',
+      key3: 'why',
+      key5: null
+    });
+  });
+
 });

--- a/test/sanitize.test.js
+++ b/test/sanitize.test.js
@@ -123,40 +123,6 @@ describe('sanitize', () => {
       key1: 'b\0ar',
       key2: '   bye',
       key3: '\0why  ',
-      key4: '',
-      key5: null
-    };
-
-    const defaultResult = Sanitize(input);
-    const overrideResult = Sanitize(input, {
-      fieldOverride: {
-        key4: {
-          pruneMethod: 'replace',
-          replaceValue: null
-        }
-      }
-    });
-
-    expect(defaultResult).to.eql({
-      key1: 'bar',
-      key2: 'bye',
-      key3: 'why',
-      key5: null
-    });
-    expect(overrideResult).to.eql({
-      key1: 'bar',
-      key2: 'bye',
-      key3: 'why',
-      key4: null,
-      key5: null
-    });
-  });
-
-  it('overrides options on certain keys if fieldOverride is passed in', () => {
-    const input = {
-      key1: 'b\0ar',
-      key2: '   bye',
-      key3: '\0why  ',
       key4: ' ',
       key5: null
     };
@@ -186,7 +152,7 @@ describe('sanitize', () => {
     });
   });
 
-  it(`overrides options on nested objects if fieldOverride is passed in`, () => {
+  it('overrides options on nested objects if fieldOverride is passed in', () => {
     const input = {
       key1: {
         nested1: 'b\0ar',

--- a/test/sanitize.test.js
+++ b/test/sanitize.test.js
@@ -152,6 +152,47 @@ describe('sanitize', () => {
     });
   });
 
+  it('overrides options on certain keys with existing options if fieldOverride is passed in', () => {
+    const input = {
+      key1: 'b\0ar',
+      key2: '   bye',
+      key3: '\0why  ',
+      key4: ' ',
+      key5: null
+    };
+
+    const defaultResult = Sanitize(input, {
+      pruneMethod: 'replace',
+      replaceValue: 'hi',
+      stripNull: true
+    });
+    const overrideResult = Sanitize(input, {
+      pruneMethod: 'replace',
+      replaceValue: 'hi',
+      stripNull: true,
+      fieldOverride: {
+        key4: {
+          replaceValue: null
+        }
+      }
+    });
+
+    expect(defaultResult).to.eql({
+      key1: 'bar',
+      key2: 'bye',
+      key3: 'why',
+      key4: 'hi',
+      key5: 'hi'
+    });
+    expect(overrideResult).to.eql({
+      key1: 'bar',
+      key2: 'bye',
+      key3: 'why',
+      key4: null,
+      key5: 'hi'
+    });
+  });
+
   it('overrides options on nested objects if fieldOverride is passed in', () => {
     const input = {
       key1: {
@@ -197,6 +238,68 @@ describe('sanitize', () => {
       key2: 'bye',
       key3: {
         nested1: 'bar'
+      },
+      key4: 'bye'
+    });
+  });
+
+  it('overrides options on nested objects with existing options if fieldOverride is passed in', () => {
+    const input = {
+      key1: {
+        nested1: 'b\0ar',
+        nested2: '',
+        nested3: '  '
+      },
+      key2: 'bye',
+      key3: {
+        nested1: 'b\0ar',
+        nested2: '',
+        nested3: '  '
+      },
+      key4: '\0bye '
+    };
+
+    const defaultResult = Sanitize(input, {
+      pruneMethod: 'replace',
+      replaceValue: 'hi',
+      stripNull: true
+    });
+    const overrideResult = Sanitize(input, {
+      pruneMethod: 'replace',
+      replaceValue: 'hi',
+      stripNull: true,
+      fieldOverride: {
+        key1: {
+          replaceValue: undefined
+        }
+      }
+    });
+
+    expect(defaultResult).to.eql({
+      key1: {
+        nested1: 'bar',
+        nested2: 'hi',
+        nested3: 'hi'
+      },
+      key2: 'bye',
+      key3: {
+        nested1: 'bar',
+        nested2: 'hi',
+        nested3: 'hi'
+      },
+      key4: 'bye'
+    });
+    expect(overrideResult).to.eql({
+      key1: {
+        nested1: 'bar',
+        nested2: undefined,
+        nested3: undefined
+      },
+      key2: 'bye',
+      key3: {
+        nested1: 'bar',
+        nested2: 'hi',
+        nested3: 'hi'
       },
       key4: 'bye'
     });


### PR DESCRIPTION
**What**: Add functionality to override specified keys with other options.

**Why**: There may be instances where some endpoints only require certain fields to be sanitized. The default behavior before was to sanitize the entire payload for an endpoint, but now it is possible for users to choose which attributes they want sanitized differently via an override.

**Details**:
* The override only applies to the top-level attributes, aka we wouldn't be able to pass in a `fieldOverride` key for a child object as well due to how I've structured the Joi schema. For instance,

The following override is valid:
```
     fieldOverride: {
        key1: {
          pruneMethod: 'replace',
          replaceValue: undefined
        }
     }
```

The following nested override is invalid:
```
      fieldOverride: {
        key1: {
          fieldOverride: {
             pruneMethod: 'delete',
          },  
          pruneMethod: 'replace',
          replaceValue: undefined
        }
     }
```

Due to how we recursively sanitize objects, the override would also be applied recursively as we can pass in the overriden options to child objects.