### PR TITLE
 feat(nested-overrides): add option

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ server.register([
   - `'replace'` - the key will be preserved, but its value will be replaced with the value of `replaceValue`.
 - `replaceValue` - valid only when `pruneMethod` is set to `'replace'`, this value will be used as the replacement of any pruned values (ie. if configured as `null`, then `{ a: '', b: 'b' }` :arrow_right: `{ a: null, b: 'b' }`).
 - `stripNull` - a boolean value to signify whether or not `null` properties should be pruned with the same `pruneMethod` and `replaceValue` as above. Defaults to `false`.
-- `fieldOverrides` - an object where each key is a a property and its value is an object of options (`pruneMethod`, `replaceValue`, and `stripNull`). The options value overrides the default options for that given property.
+- `fieldOverrides` - an object where each key is a property and its value is an object of options (`pruneMethod`, `replaceValue`, and `stripNull`). The options value overrides the default options for that given property.
+- `nestedOverrides` - an object where each key is a property and its value is an object of options (`pruneMethod`, `replaceValue`, and `stripNull`). The options value overrides the default options applied to the nested object of that property. The default options for that property are considered the options after the fieldOverrides are applied.
 
 Each of the above options can be configured on a route-by-route basis via the `sanitize` plugin object.
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -21,7 +21,8 @@ const options = Joi.object().keys({
 const schema = Joi.object().keys({
   enabled: Joi.boolean().optional(),
   // no double quotes or backslashes
-  fieldOverrides: Joi.object().pattern(/^[^"\\]$/, options).optional()
+  fieldOverrides: Joi.object().pattern(/^[^"\\]$/, options).optional(),
+  nestedOverrides: Joi.object().pattern(/^[^"\\]$/, options).optional()
 }).concat(options);
 
 exports.defaults = defaults;

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -32,7 +32,11 @@ function Sanitize (object, options) {
     let value = object[key];
 
     if (IsPlainObject(value)) {
-      object[key] = Sanitize(value, overrideOptions);
+      const nestedOverrides = options.nestedOverrides ? options.nestedOverrides[key] : {};
+      const nestedOptions = Object.assign({}, overrideOptions, nestedOverrides);
+      Reflect.deleteProperty(nestedOptions, 'nestedOverrides');
+
+      object[key] = Sanitize(value, nestedOptions);
     } else {
       if (IsString(value)) {
         object[key] = value = stripNullTerminator(value).trim();

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -26,17 +26,15 @@ function Sanitize (object, options) {
 
   Object.keys(object).forEach((key) => {
     const fieldOptions = options.fieldOverrides ? options.fieldOverrides[key] : {};
-    const overrideOptions = Object.assign({}, options, {
-      fieldOverrides: {}
-    }, fieldOptions);
+    const overrideOptions = Object.assign({}, options, fieldOptions);
+    overrideOptions.fieldOverrides = {};
 
     let value = object[key];
 
     if (IsPlainObject(value)) {
       const nestedOverrides = options.nestedOverrides ? options.nestedOverrides[key] : {};
-      const nestedOptions = Object.assign({}, overrideOptions, {
-        nestedOverrides: {}
-      }, nestedOverrides);
+      const nestedOptions = Object.assign({}, overrideOptions, nestedOverrides);
+      nestedOptions.nestedOverrides = {};
 
       object[key] = Sanitize(value, nestedOptions);
     } else {

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -27,6 +27,7 @@ function Sanitize (object, options) {
   Object.keys(object).forEach((key) => {
     const fieldOptions = options.fieldOverrides ? options.fieldOverrides[key] : {};
     const overrideOptions = Object.assign({}, options, fieldOptions);
+    Reflect.deleteProperty(overrideOptions, 'fieldOverrides');
 
     let value = object[key];
 

--- a/lib/sanitize.js
+++ b/lib/sanitize.js
@@ -26,15 +26,17 @@ function Sanitize (object, options) {
 
   Object.keys(object).forEach((key) => {
     const fieldOptions = options.fieldOverrides ? options.fieldOverrides[key] : {};
-    const overrideOptions = Object.assign({}, options, fieldOptions);
-    Reflect.deleteProperty(overrideOptions, 'fieldOverrides');
+    const overrideOptions = Object.assign({}, options, {
+      fieldOverrides: {}
+    }, fieldOptions);
 
     let value = object[key];
 
     if (IsPlainObject(value)) {
       const nestedOverrides = options.nestedOverrides ? options.nestedOverrides[key] : {};
-      const nestedOptions = Object.assign({}, overrideOptions, nestedOverrides);
-      Reflect.deleteProperty(nestedOptions, 'nestedOverrides');
+      const nestedOptions = Object.assign({}, overrideOptions, {
+        nestedOverrides: {}
+      }, nestedOverrides);
 
       object[key] = Sanitize(value, nestedOptions);
     } else {

--- a/test/sanitize.test.js
+++ b/test/sanitize.test.js
@@ -282,7 +282,7 @@ describe('sanitize', () => {
     });
   });
 
-  it('fieldOverrides do not persist to nested values', () => {
+  it('fieldOverrides do not persist to other nested values', () => {
     const input = {
       key: {
         key2: null

--- a/test/sanitize.test.js
+++ b/test/sanitize.test.js
@@ -287,6 +287,7 @@ describe('sanitize', () => {
       key: {
         key2: null
       },
+      key2: null,
       other: null
     };
 
@@ -310,6 +311,7 @@ describe('sanitize', () => {
       key: {
         key2: 1
       },
+      key2: 2,
       other: 0
     });
   });
@@ -408,6 +410,9 @@ describe('sanitize', () => {
             key: null
           }
         },
+        key2: {
+          key: null
+        },
         other: null
       };
 
@@ -432,6 +437,9 @@ describe('sanitize', () => {
           key2: {
             key: 1
           }
+        },
+        key2: {
+          key: 2
         },
         other: 0
       });

--- a/test/sanitize.test.js
+++ b/test/sanitize.test.js
@@ -314,4 +314,129 @@ describe('sanitize', () => {
     });
   });
 
+  describe('nestedOverrides', () => {
+
+    it('uses options for nested fields', () => {
+      const input = {
+        key: null
+      };
+
+      const nestedInput = {
+        key: {
+          nested: null
+        }
+      };
+
+      const options = {
+        stripNull: true,
+        nestedOverrides: {
+          key: {
+            stripNull: false
+          }
+        }
+      };
+
+      const result = Sanitize(input, options);
+      const nestedResult = Sanitize(nestedInput, options);
+
+      expect(result).to.eql({});
+      expect(nestedResult).to.eql(nestedInput);
+    });
+
+    it('overrides fieldOverrides options', () => {
+      const input = {
+        key: {
+          nested: null
+        }
+      };
+
+      const options = {
+        pruneMethod: 'replace',
+        replaceValue: 0,
+        stripNull: true,
+        fieldOverrides: {
+          key: {
+            replaceValue: 2
+          }
+        },
+        nestedOverrides: {
+          key: {
+            replaceValue: 1
+          }
+        }
+      };
+
+      const result = Sanitize(input, options);
+
+      expect(result).to.eql({
+        key: {
+          nested: 1
+        }
+      });
+    });
+
+    it('ignores nestedOverrides if not object', () => {
+      const input = {
+        key: null
+      };
+
+      const options = {
+        pruneMethod: 'replace',
+        replaceValue: 0,
+        stripNull: true,
+        fieldOverrides: {
+          key: {
+            replaceValue: 2
+          }
+        },
+        nestedOverrides: {
+          key: {
+            replaceValue: 1
+          }
+        }
+      };
+
+      const result = Sanitize(input, options);
+
+      expect(result).to.eql({ key: 2 });
+    });
+
+    it('do not affect other nested objects', () => {
+      const input = {
+        key: {
+          key2: {
+            key: null
+          }
+        },
+        other: null
+      };
+
+      const options = {
+        pruneMethod: 'replace',
+        replaceValue: 0,
+        stripNull: true,
+        nestedOverrides: {
+          key: {
+            replaceValue: 1
+          },
+          key2: {
+            replaceValue: 2
+          }
+        }
+      };
+
+      const result = Sanitize(input, options);
+
+      expect(result).to.eql({
+        key: {
+          key2: {
+            key: 1
+          }
+        },
+        other: 0
+      });
+    });
+
+  });
+
 });

--- a/test/sanitize.test.js
+++ b/test/sanitize.test.js
@@ -282,4 +282,36 @@ describe('sanitize', () => {
     });
   });
 
+  it('fieldOverrides do not persist to nested values', () => {
+    const input = {
+      key: {
+        key2: null
+      },
+      other: null
+    };
+
+    const options = {
+      pruneMethod: 'replace',
+      replaceValue: 0,
+      stripNull: true,
+      fieldOverrides: {
+        key: {
+          replaceValue: 1
+        },
+        key2: {
+          replaceValue: 2
+        }
+      }
+    };
+
+    const result = Sanitize(input, options);
+
+    expect(result).to.eql({
+      key: {
+        key2: 1
+      },
+      other: 0
+    });
+  });
+
 });


### PR DESCRIPTION
### Context
When we introduced `fieldOverrides`, it wasn't realized that this doesn't actually solve the problem we wanted to solve. We wanted to be able to change options for nested fields only. 

We really wanted the following behavior:
```js
const options = { 
  stripNull: true,
  nestedOptions: {
    key: {
      stripNull: false
    }
  }
};

const input1 = {
  key: null
};
const sanitized = {};

const input2 = {
  key: {
    nested: null
  }
};
const sanitized2 = {
  key: {
    nested: null
  }
};
```

To obtain that, we've added `nestedOverrides` to apply options nested fields of fields that contain objects.

I also found a separate bug with the `fieldOverrides`. As it stood, it was possible for `overrideOptions` to affect nested fields with the same property name. As it stands, past the first level, the overrides are deleted. 

### What
- [x] Add `nestedOverrides` option. 
- [x] Fix separate bug with option pollution of nested options bleeding from other fields due to name collision in `fieldOverrides`. 